### PR TITLE
Replace 'ifconfig' with 'ip addr show'

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ SENTRY_DSN=https://vx547s32f45d7v91q865hgh5421z8932@f584318.ingest.sentry.io/671
 
 #### *HOST*
 
-Simply open terminal and type `ifconfig` (MacOS / Linux-based OS) or `ipconfig` (Windows). You should see like `192.168.1.4` which is the value of this variable.<br>
+Simply open terminal and type `ip addr show` (MacOS / Linux-based OS) or `ipconfig` (Windows). You should see like `192.168.1.4` which is the value of this variable.<br>
 Example : 
 ```bash
 HOST=http://192.168.1.4


### PR DESCRIPTION
```
osboxes@osboxes:~/strapi-custom-learning$ ifconfig

Command 'ifconfig' not found, but can be installed with:

sudo apt install net-tools
```

https://www.redhat.com/sysadmin/ifconfig-vs-ip#:~:text=ifconfig%20has%20been%20officially%20deprecated,move%20on%20with%20the%20world.&text=The%20dev%20flag%20is%20used,address%20is%20being%20set%20on.

```ifconfig``` is a deprecated tool and is not installed on new versions of Linux. The tool to use is ```ip addr show```.